### PR TITLE
Error during installation

### DIFF
--- a/run_syncasm.c
+++ b/run_syncasm.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <math.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "kvec.h"
 #include "kstring.h"

--- a/syncasm.c
+++ b/syncasm.c
@@ -35,6 +35,7 @@
 #include <float.h>
 #include <pthread.h>
 #include <assert.h>
+#include <limits.h>
 
 #include "kvec.h"
 #include "kdq.h"

--- a/syncasm.c
+++ b/syncasm.c
@@ -35,7 +35,6 @@
 #include <float.h>
 #include <pthread.h>
 #include <assert.h>
-#include <limits.h>
 
 #include "kvec.h"
 #include "kdq.h"

--- a/syncerr.c
+++ b/syncerr.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <math.h>
 #include <pthread.h>
+#include <limits.h>
 
 #include "kvec.h"
 #include "kstring.h"


### PR DESCRIPTION
Dear @c-zhou ,
During the software installation, I encountered two errors:

`gcc -g -Wall -O3 -Wno-unused-function -DSYNCASM_MAIN run_syncasm.c syncasm.c syncmer.c syncerr.c levdist.c graph.c alignment.c sstream.c misc.c kthread.c kalloc.c kopen.c -o syncasm -L. -lm -lz -lpthread 
run_syncasm.c: In function ‘syncasm’:
run_syncasm.c:190:49: error: ‘INT_MAX’ undeclared (first use in this function)
         cleaned += asmg_drop_tip(scg->utg_asmg, INT_MAX, tip_size, 1, 0, VERBOSE);
                                                 ^
run_syncasm.c:190:49: note: each undeclared identifier is reported only once for each function it appears in
syncerr.c: In function ‘dfs_info_reset’:
syncerr.c:104:18: error: ‘INT_MAX’ undeclared (first use in this function)
     dfs->edist = INT_MAX;
                  ^
syncerr.c:104:18: note: each undeclared identifier is reported only once for each function it appears in
`
To address this issue, I added #include <limits.h> to both run_syncasm.c and syncerr.c, and the errors were resolved. I'm not sure if this approach is acceptable. If possible you can take a look at it.

Best.
